### PR TITLE
changed limit rows default to false

### DIFF
--- a/models/staging/stg_green_tripdata.sql
+++ b/models/staging/stg_green_tripdata.sql
@@ -41,7 +41,7 @@ select
 from tripdata
 where rn = 1
 
-{% if var('is_test_run', default=true) %}
+{% if var('is_test_run', default=false) %}
 
     limit 100
 

--- a/models/staging/stg_yellow_tripdata.sql
+++ b/models/staging/stg_yellow_tripdata.sql
@@ -41,7 +41,7 @@ select
 from tripdata
 where rn = 1
 
-{% if var('is_test_run', default=true) %}
+{% if var('is_test_run', default=false) %}
 
     limit 100
 


### PR DESCRIPTION
production tables have limited number of rows; found the limit defaults to 100; defaulting the clause to false